### PR TITLE
Fix/item list parse items

### DIFF
--- a/tests/test_item_lists.py
+++ b/tests/test_item_lists.py
@@ -43,13 +43,13 @@ class ItemListsTestCase(unittest.TestCase):
         cls.item_list = {
             'name': 'Test list',
             'items': [
-                'item one',
-                'item two',
-                'item three'
+                {'content': 'item one'},
+                {'content': 'item two'},
+                {'content': 'item three'}
             ],
             'items_checked': [
-                'item four',
-                'item five'
+                {'content': 'item four'},
+                {'content': 'item five'}
             ],
             'private': True
         }
@@ -57,23 +57,23 @@ class ItemListsTestCase(unittest.TestCase):
         cls.item_list2 = {
             'name': 'Test list 2',
             'items': [
-                'This list has less items',
+                {'content': 'This list has less items'},
             ],
             'items_checked': [
-                'only one checked',
+                {'content': 'only one checked'},
             ]
         }
 
         cls.item_list_public = {
             'name': 'Test list public',
             'items': [
-                'item one',
-                'item two',
-                'item three'
+                {'content': 'item one'},
+                {'content': 'item two'},
+                {'content': 'item three'}
             ],
             'items_checked': [
-                'item four',
-                'item five'
+                {'content': 'item four'},
+                {'content': 'item five'}
             ],
             'private': False
         }
@@ -87,11 +87,11 @@ class ItemListsTestCase(unittest.TestCase):
 
         cls.item_to_add = {
             'items': [
-                'item one',
-                'item two',
+                {'content': 'item one'},
+                {'content': 'item two'},
             ],
             'items_checked': [
-                'item three'
+                {'content': 'item three'}
             ]
         }
 
@@ -431,37 +431,127 @@ class ItemListsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
 
-        self.assertEqual(data['count'], 2)
-        self.assertEqual(data['item_list'][0]['id'], 1)
-        self.assertEqual(data['item_list'][0]['name'], self.item_list['name'])
-        self.assertEqual(data['item_list'][0]['owner'], self.user1.id)
-        self.assertEqual(data['item_list'][0]['private'], self.item_list['private'])
-        self.assertEqual(data['item_list'][0]['items'][0]['content'], self.item_list['items'][0])
-        self.assertEqual(data['item_list'][0]['items'][0]['owner'], data['item_list'][0]['owner'])
-        self.assertEqual(data['item_list'][0]['items'][0]['item_list'], data['item_list'][0]['id'])
-        self.assertEqual(data['item_list'][0]['items'][1]['content'], self.item_list['items'][1])
-        self.assertEqual(data['item_list'][0]['items'][1]['owner'], data['item_list'][0]['owner'])
-        self.assertEqual(data['item_list'][0]['items'][1]['item_list'], data['item_list'][0]['id'])
-        self.assertEqual(data['item_list'][0]['items'][2]['content'], self.item_list['items'][2])
-        self.assertEqual(data['item_list'][0]['items'][2]['owner'], data['item_list'][0]['owner'])
-        self.assertEqual(data['item_list'][0]['items'][2]['item_list'], data['item_list'][0]['id'])
-        self.assertEqual(data['item_list'][0]['items_checked'][0]['content'], self.item_list['items_checked'][0])
-        self.assertEqual(data['item_list'][0]['items_checked'][0]['owner'], data['item_list'][0]['owner'])
-        self.assertEqual(data['item_list'][0]['items_checked'][0]['item_list'], data['item_list'][0]['id'])
-        self.assertEqual(data['item_list'][0]['items_checked'][1]['content'], self.item_list['items_checked'][1])
-        self.assertEqual(data['item_list'][0]['items_checked'][1]['owner'], data['item_list'][0]['owner'])
-        self.assertEqual(data['item_list'][0]['items_checked'][1]['item_list'], data['item_list'][0]['id'])
+        self.assertEqual(
+            data['count'],
+            2
+        )
+        self.assertEqual(
+            data['item_list'][0]['id'],
+            1
+        )
+        self.assertEqual(
+            data['item_list'][0]['name'],
+            self.item_list['name']
+        )
+        self.assertEqual(
+            data['item_list'][0]['owner'],
+            self.user1.id
+        )
+        self.assertEqual(
+            data['item_list'][0]['private'],
+            self.item_list['private']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][0]['content'],
+            self.item_list['items'][0]['content']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][0]['owner'],
+            data['item_list'][0]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][0]['item_list'],
+            data['item_list'][0]['id']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][1]['content'],
+            self.item_list['items'][1]['content']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][1]['owner'],
+            data['item_list'][0]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][1]['item_list'],
+            data['item_list'][0]['id']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][2]['content'],
+            self.item_list['items'][2]['content']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][2]['owner'],
+            data['item_list'][0]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items'][2]['item_list'],
+            data['item_list'][0]['id']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][0]['content'],
+            self.item_list['items_checked'][0]['content']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][0]['owner'],
+            data['item_list'][0]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][0]['item_list'],
+            data['item_list'][0]['id']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][1]['content'],
+            self.item_list['items_checked'][1]['content']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][1]['owner'],
+            data['item_list'][0]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][0]['items_checked'][1]['item_list'],
+            data['item_list'][0]['id']
+        )
 
-        self.assertEqual(data['item_list'][1]['id'], 2)
-        self.assertEqual(data['item_list'][1]['name'], self.item_list2['name'])
-        self.assertEqual(data['item_list'][1]['owner'], self.user1.id)
-        self.assertEqual(data['item_list'][1]['private'], True)
-        self.assertEqual(data['item_list'][1]['items'][0]['content'], self.item_list2['items'][0])
-        self.assertEqual(data['item_list'][1]['items'][0]['owner'], data['item_list'][1]['owner'])
-        self.assertEqual(data['item_list'][1]['items'][0]['item_list'], data['item_list'][1]['id'])
-        self.assertEqual(data['item_list'][1]['items_checked'][0]['content'], self.item_list2['items_checked'][0])
-        self.assertEqual(data['item_list'][1]['items_checked'][0]['owner'], data['item_list'][1]['owner'])
-        self.assertEqual(data['item_list'][1]['items_checked'][0]['item_list'], data['item_list'][1]['id'])
+        self.assertEqual(
+            data['item_list'][1]['id'],
+            2
+        )
+        self.assertEqual(
+            data['item_list'][1]['name'],
+            self.item_list2['name']
+        )
+        self.assertEqual(
+            data['item_list'][1]['owner'],
+            self.user1.id
+        )
+        self.assertEqual(
+            data['item_list'][1]['private'],
+            True
+        )
+        self.assertEqual(
+            data['item_list'][1]['items'][0]['content'],
+            self.item_list2['items'][0]['content']
+        )
+        self.assertEqual(
+            data['item_list'][1]['items'][0]['owner'],
+            data['item_list'][1]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][1]['items'][0]['item_list'],
+            data['item_list'][1]['id']
+        )
+        self.assertEqual(
+            data['item_list'][1]['items_checked'][0]['content'],
+            self.item_list2['items_checked'][0]['content']
+        )
+        self.assertEqual(
+            data['item_list'][1]['items_checked'][0]['owner'],
+            data['item_list'][1]['owner']
+        )
+        self.assertEqual(
+            data['item_list'][1]['items_checked'][0]['item_list'],
+            data['item_list'][1]['id']
+        )
 
     def test_get_all_public_list(self):
         # User1

--- a/tests/test_trip.py
+++ b/tests/test_trip.py
@@ -51,15 +51,14 @@ class TripsTestCase(unittest.TestCase):
         cls.item_list = {
             'name': 'Test list',
             'items': [
-                'item one',
-                'item two',
-                'item three'
+                {'content': 'item one'},
+                {'content': 'item two'},
+                {'content': 'item three'}
             ],
             'items_checked': [
-                'item four',
-                'item five'
+                {'content': 'item four'},
+                {'content': 'item five'}
             ],
-            'type': 'check'
         }
         cls.trip = {
             'name': 'UTrippin?',

--- a/turplanlegger/database/schema.sql
+++ b/turplanlegger/database/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS lists_items (
     id serial PRIMARY KEY,
     content text,
     checked boolean DEFAULT FALSE,
-    item_list int REFERENCES item_lists (id),
+    item_list int REFERENCES item_lists (id) NOT NULL,
     owner text REFERENCES users (id),
     create_time timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted boolean DEFAULT FALSE,

--- a/turplanlegger/models/item_lists.py
+++ b/turplanlegger/models/item_lists.py
@@ -60,6 +60,15 @@ class ItemList:
         self.items_checked = kwargs.get('items_checked', [])
         self.create_time = kwargs.get('create_time', None) or datetime.now()
 
+    def __repr__(self):
+        return (
+            'ItemList('
+            f'id: {self.id}, owner: {self.owner}, '
+            f'name: {self.name}, items: {self.items},'
+            f'items_checked: {self.items_checked}, '
+            f'create_time: {self.create_time})'
+            )
+
     @classmethod
     def parse(cls, json: JSON) -> 'ItemList':
         """Parse input JSON and return a ItemList object.

--- a/turplanlegger/models/item_lists.py
+++ b/turplanlegger/models/item_lists.py
@@ -70,20 +70,15 @@ class ItemList:
         Returns:
             A ItemList object
         """
-
         items = json.get('items', [])
         if not isinstance(items, list):
             raise TypeError("'items' must be JSON list")
-        for i, item in enumerate(items):
-            if item is not None and len(item) > 512:
-                raise ValueError(f"item {i+1}:'{item}' is too long, max 512 char")
+        items[:] = [ItemList.parse(item) for item in items]
 
         items_checked = json.get('items_checked', [])
         if not isinstance(items_checked, list):
             raise TypeError("'items_checed' must be JSON list")
-        for i, item in enumerate(items_checked):
-            if item is not None and len(item) > 512:
-                raise ValueError(f"checked item {i+1}:'{item}' is too long, max 512 char")
+        items_checked[:] = [ItemList.parse(item) for item in items_checked]
 
         return ItemList(
             id=json.get('id', None),
@@ -114,21 +109,11 @@ class ItemList:
         """
         item_list = self.get_item_list(db.create_item_list(self))
         if self.items:
-            items = [ListItem(
-                owner=item_list.owner,
-                item_list=item_list.id,
-                checked=False,
-                content=item) for item in self.items]
-            items = [item.create() for item in items]
+            items = [item.create() for item in self.items]
             item_list.items, self.items = [items, items]
 
         if self.items_checked:
-            items_checked = [ListItem(
-                owner=item_list.owner,
-                item_list=item_list.id,
-                checked=True,
-                content=item) for item in self.items_checked]
-            items_checked = [item.create() for item in items_checked]
+            items_checked = [item.create() for item in self.items_checked]
             item_list.items_checked, self.items_checked = [items_checked, items_checked]
 
         return item_list

--- a/turplanlegger/models/item_lists.py
+++ b/turplanlegger/models/item_lists.py
@@ -68,7 +68,7 @@ class ItemList:
             f'items_count: {len(self.items)}, items: {self.items}, '
             f'items_checked_count: {len(self.items_checked)}, items_checked: {self.items_checked}, '
             f'create_time: {self.create_time})'
-            )
+        )
 
     @classmethod
     def parse(cls, json: JSON) -> 'ItemList':

--- a/turplanlegger/models/list_items.py
+++ b/turplanlegger/models/list_items.py
@@ -50,6 +50,14 @@ class ListItem:
         self.content = kwargs.get('content')
         self.create_time = kwargs.get('create_time', None) or datetime.now()
 
+    def __repr__(self):
+        return (
+            'ListItem('
+            f'id: {self.id}, owner: {self.owner} '
+            f'item_list: {self.item_list}, checked: {self.checked} '
+            f'content: {self.content}, create_time: {self.create_time})'
+        )
+
     @classmethod
     def parse(cls, json: JSON) -> 'ListItem':
         """Parse input JSON and return a ListItem object.

--- a/turplanlegger/models/list_items.py
+++ b/turplanlegger/models/list_items.py
@@ -1,6 +1,7 @@
-from flask import g
 from datetime import datetime
 from typing import Dict, NamedTuple
+
+from flask import g
 
 from turplanlegger.app import db
 

--- a/turplanlegger/models/list_items.py
+++ b/turplanlegger/models/list_items.py
@@ -1,3 +1,4 @@
+from flask import g
 from datetime import datetime
 from typing import Dict, NamedTuple
 
@@ -26,15 +27,11 @@ class ListItem:
                                 Default: datetime.now()
     """
 
-    def __init__(self, owner: str, item_list: int, checked: bool, **kwargs) -> None:
+    def __init__(self, owner: str, checked: bool, **kwargs) -> None:
         if not owner:
             raise ValueError("missing mandatory field 'owner'")
         if not isinstance(owner, str):
             raise TypeError("'owner' must be str")
-        if not item_list:
-            raise ValueError("missing mandatory field 'item_list'")
-        if not isinstance(item_list, int):
-            raise TypeError("'item_list' must be integer")
         if not isinstance(checked, bool):
             raise TypeError("'checked' must be boolean")
 
@@ -44,7 +41,7 @@ class ListItem:
 
         self.id = kwargs.get('id', None)
         self.owner = owner
-        self.item_list = item_list
+        self.item_list = kwargs.get('item_list', None)
         self.checked = checked
 
         self.content = kwargs.get('content')
@@ -53,8 +50,8 @@ class ListItem:
     def __repr__(self):
         return (
             'ListItem('
-            f'id: {self.id}, owner: {self.owner} '
-            f'item_list: {self.item_list}, checked: {self.checked} '
+            f'id: {self.id}, owner: {self.owner}, '
+            f'item_list: {self.item_list}, checked: {self.checked}, '
             f'content: {self.content}, create_time: {self.create_time})'
         )
 
@@ -74,6 +71,28 @@ class ListItem:
             owner=json.get('owner', None),
             item_list=json.get('item_list', None),
             checked=json.get('checked', False),
+            content=json.get('content', None)
+        )
+
+    @classmethod
+    def parse_for_item_list(cls, json: JSON, checked: bool = False) -> 'ListItem':
+        """Parse input JSON when creating ListItems
+           while creating ItemList.
+           Owner is fetched from Flask.g
+
+        Args:
+            json (Dict[str, any]): JSON input object
+            checked (bool): Flag if ListItem is checked
+
+        Returns:
+            A ListItem object
+        """
+
+        return ListItem(
+            id=json.get('id', None),
+            owner=g.user.id,
+            item_list=json.get('item_list', None),
+            checked=checked,
             content=json.get('content', None)
         )
 

--- a/turplanlegger/views/item_lists.py
+++ b/turplanlegger/views/item_lists.py
@@ -76,7 +76,7 @@ def add_item_list_items(item_list_id):
                     'owner': g.user.id,
                     'item_list': item_list.id,
                     'checked': False,
-                    'content': item
+                    'content': item.get('content')
                 }
             ) for item in items
         ]
@@ -86,7 +86,7 @@ def add_item_list_items(item_list_id):
                     'owner': g.user.id,
                     'item_list': item_list.id,
                     'checked': True,
-                    'content': item
+                    'content':  item.get('content')
                 }
             ) for item in items_checked
         ]


### PR DESCRIPTION
Added:
 - repr method for `ItemList` and `ListItem`
 - Parsing of `ListItem` when creating `ItemList`

Changed:
 - `ListItem` instance does not require `item_list`
 - `list_item` table require `list_item REFERENCE`